### PR TITLE
Update td.join.R

### DIFF
--- a/R/td.join.R
+++ b/R/td.join.R
@@ -1,8 +1,8 @@
 td.join <-
-function(tdf1, tdf2, otable="newJoinTable", odatabase="",
+function(tdf1, tdf2, oTable="newJoinTable", oDatabase="",
                    index1="", index2="", joinType="inner")
 {
-  oObj <- .td.object(otable,odatabase)
+  oObj <- .td.object(oTable,oDatabase)
   if(missing(index1))
     index1 <- .td.getPrimaryIndicies(tdf1)
   if(missing(index2))


### PR DESCRIPTION
Changed variable names to fix a bug when returning the td.data.frame.  Input variables are otable and odatabase and were used as otable in one place and oTable in another.  Changed all to oTable and oDatabase.
